### PR TITLE
update search script for newer Watson service

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,22 @@ filter metadata if `sidebar` value is present in the call.
 ## Deployment
 
 Any changes made to this repository will need to be reflect in IBM Cloud by updating the
-Function code. Currently deployed to a Node 8 runtime.
+Function code. Currently deployed to a Node 10 runtime.
+
+Make sure you have Watson Discovery service created on IBM Cloud. 
+
+1. Create a Cloud function in https://cloud.ibm.com/functions/
+2. Go to Parameters tab, set the following parameters:
+
+| Parameter Name    | Parameter Value |
+| ----------------- |:-------------:| 
+| discovery_url     | `url` in Watson Discovery service credentials    | 
+| discovery_apikey  | `apikey` in Watson Discovery service credentials |   
+  
+3. Go to Code tab, copy content in `search.js` in the text area.
+4. Go to Endpoints tab, Make sure the checkbox "Enable as Web Action" is checked. In this case, you'll have a public API.
+
+The Cloud function is set up and ready to run.
 
 ## Contributions
 

--- a/search.js
+++ b/search.js
@@ -18,10 +18,13 @@ function main(params) {
   }
 
   // Initialize Watson Discovery
+  // From the Watson Discovery service on IBM Cloud, 
+  // `iam_apikey`: `apikey` in the service credential
+  // `url`: `url` in the service credential
   const discovery = new DiscoveryV1({
-    version: '2018-03-05',
-    username: params.discovery_username,
-    password: params.discovery_password
+    version: "2018-12-03",
+    iam_apikey: params.discovery_apikey,
+    url: params.discovery_url
   });
 
   return new Promise(function(resolve, reject) {
@@ -75,35 +78,11 @@ function main(params) {
           collection_id: collectionID,
           natural_language_query: params.q,
           highlight: true,
-          return_fields: ['metadata']
         };
-
-        // Filter based on sidebar metadata if present.
-        // Include Contribute and Community Sidebars as default as well
-        // as the English version of docs (if a different language sidebar) is set.
-        if (params.sidebar) {
-          const sidebars = ['contrib_sidebar', 'community_sidebar'];
-          if (params.sidebar.split('_').length > 2) {
-            sidebars.push(
-              params.sidebar
-                .split('_')
-                .splice(1)
-                .join('_')
-            );
-          }
-          sidebars.push(params.sidebar);
-
-          let filter;
-          sidebars.map(x => {
-            x = `metadata.sidebar:"${x}"`;
-          });
-          filter = `(${sidebars.join('|')})`;
-          data.filter = filter;
-        }
 
         // Query offset
         if (params.offset) {
-          data.offset = params.offset;
+         data.offset = params.offset;
         }
 
         // Make the query to Watson Discovery -- Return results to user.


### PR DESCRIPTION
- Update the `search.js` to use the latest Watson Discovery service. 
- Update deployment section of README to include instructions on how to set things up.